### PR TITLE
LTA-84: Setup Vagrant Development Environment.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ examples/db_team_bot/
 .DS_Store
 */.DS_Store
 .env
+.vagrant/

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,26 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Provisioning script that installs redis/nodejs and sets environment variables
+$provision = <<SCRIPT
+  yum update
+  yum install -y wget
+  # Install Redis
+  wget -r --no-parent -A 'epel-release-*.rpm' http://dl.fedoraproject.org/pub/epel/7/x86_64/e/
+  rpm -Uvh dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-*.rpm
+  yum install -y redis
+  systemctl start redis.service
+  # Install Node/npm
+  curl --silent --location https://rpm.nodesource.com/setup_6.x | bash -
+  yum install -y nodejs
+  # Set environment variables
+  echo 'REDISCLOUD_URL=redis://libotrio:libotrio@localhost:6379' >> /etc/environment
+  # Cleanup
+  rm -r dl.fedoraproject.org
+SCRIPT
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "centos/7"
+  config.vm.provision "shell", inline: $provision
+end
+


### PR DESCRIPTION
Set up a Vagrant box that provisions itself with Redis and Node/npm for developers to run Libotrio in. Updated [documentation](https://liatrio.atlassian.net/wiki/display/LTA/Liatrio+Internal+Tool%3A+Libotrio).